### PR TITLE
Fix activity range end index when SWEEP ACTIVITY string is missing

### DIFF
--- a/libs/parser.py
+++ b/libs/parser.py
@@ -15,11 +15,12 @@ from libs import (
 
 
 def get_activity_range(page_strings):
-    begin_index = None
-    end_index = None
+    begin_index = 0
+    end_index = 0
     for index, page_string in enumerate(page_strings):
         if page_string == "Amount":
             begin_index = index
+            end_index = len(page_strings)
             continue
 
         if page_string == "SWEEP ACTIVITY":


### PR DESCRIPTION
Set end_index for activities to the end of the page by default when activities are found. Because of missing `SWEEP ACTIVITY` string sometimes. Otherwise, activities can be missed.