### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Pillow==8.1.0
 pycryptodome==3.9.9
 python-dateutil==2.8.1
 six==1.15.0
+testresources==2.0.0


### PR DESCRIPTION
**Issue**: Doing a `pip install -r requirements.txt` as instructed returned an error `launchpadlib 1.10.13 requires testresources, which is not installed.` on my Ubuntu Server 20.04 LTS.
**Solution**: Adding the `testresources` package to the requirements list fixed this for me.